### PR TITLE
Workaround for cuDNN insane workspace size bug.

### DIFF
--- a/maxdnn/Makefile
+++ b/maxdnn/Makefile
@@ -14,7 +14,7 @@ EXTERNALS=$(HOME)/develop/externals
 CUDA_PATH=/usr/local/cuda
 CUDNN_PATH=$(EXTERNALS)/cudnn-6.5-linux-x64-v2-rc2
 UNITTEST_PATH=/usr/local/include/UnitTest++
-MAXAS_PATH=$(EXTERNALS)/maxas
+MAXAS_PATH=$(EXTERNALS)/maxas/bin
 
 INCLUDE=-I.. -I$(UNITTEST_PATH) -I$(CUDA_PATH)/include -I$(CUDA_PATH)/samples/common/inc -I. -I$(CUDNN_PATH)
 

--- a/maxdnn/maxdnn_test.cpp
+++ b/maxdnn/maxdnn_test.cpp
@@ -4,6 +4,7 @@ Licensed under the MIT License
 */
 #include "maxdnn/maxdnn_test.hpp"
 #include "maxdnn/FileName.hpp"
+#include <sstream>
 #include <stdlib.h>
 using namespace maxdnn;
 using namespace std;
@@ -17,9 +18,11 @@ namespace
     const char *maxdnn_test_no_test = "maxdnn_test_no_test";
     const char *maxdnn_test_conv_iters = "maxdnn_test_conv_iters";
     const char *maxdnn_test_cooldown = "maxdnn_test_cooldown";
+    const char *maxdnn_max_workspace_size = "maxdnn_max_workspace_size";
     const int DefaultDevice = 0;
     const int DefaultConvIters = 10;
     const int DefaultCooldown = 0;
+    const int DefaultMaxWorkspaceSize = static_cast<size_t>(1) << 30;
 
     int getEnvFlag(const char* varname, int defaultValue=0)
     {
@@ -29,6 +32,17 @@ namespace
             flag = atoi(flag_str);
         }
         return flag;
+    }
+
+    size_t getEnvSize(const char* varname, size_t defaultValue=0)
+    {
+        size_t size = defaultValue;
+        char *size_str = getenv(varname);
+        if (size_str) {
+            istringstream s(size_str);
+            s >> size;
+        }
+        return size;
     }
 }
 
@@ -70,3 +84,9 @@ int getTestDevice()
 {
     return getEnvFlag(maxdnn_test_device, DefaultDevice);
 }
+
+size_t getMaxWorkspaceSize()
+{
+    return getEnvSize(maxdnn_max_workspace_size, DefaultMaxWorkspaceSize);
+}
+

--- a/maxdnn/maxdnn_test.hpp
+++ b/maxdnn/maxdnn_test.hpp
@@ -12,5 +12,6 @@ bool noTest();
 int getConvIters();
 int getCooldown();
 int getTestDevice();
+size_t getMaxWorkspaceSize();
 
 #endif


### PR DESCRIPTION
The main part of this request is a fix for bug: https://github.com/eBay/maxDNN/issues/1

This is caused by cuDNN sometimes requesting an insanely large workspace size, perhaps just on certain maxwell chips. We added a maximum workspace size check, and fall back to the cuDNN "no workspace" algorithm when the maximum sized is exceeeded.

Also we updated the Makefile to point to the correct relative path of maxas.pl as it appears in the current maxas release.
